### PR TITLE
Match CircleCI badge's style with the others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cymrust [![Crates.io](https://img.shields.io/crates/v/cymrust.svg)](https://crates.io/crates/cymrust) [![docs.rs](https://docs.rs/cymrust/badge.svg)](https://docs.rs/cymrust/) [![CircleCI](https://circleci.com/gh/HowNetWorks/cymrust.svg?style=svg)](https://circleci.com/gh/HowNetWorks/cymrust)
+# cymrust [![Crates.io](https://img.shields.io/crates/v/cymrust.svg)](https://crates.io/crates/cymrust) [![docs.rs](https://docs.rs/cymrust/badge.svg)](https://docs.rs/cymrust/) [![CircleCI](https://circleci.com/gh/HowNetWorks/cymrust.svg?style=shield)](https://circleci.com/gh/HowNetWorks/cymrust)
 
 Simple library to query [Team Cymru](https://www.team-cymru.org/)'s
 [IP-to-ASN](https://www.team-cymru.org/IP-ASN-mapping.html) mapping information


### PR DESCRIPTION
Update the CircleCI badge's style to match the other badges.

Before the change:
<img width="293" alt="screen shot 2017-01-05 at 18 16 10" src="https://cloud.githubusercontent.com/assets/19776768/21687742/1d330f94-d373-11e6-975e-0f3c6417830e.png">

After the change:
<img width="328" alt="screen shot 2017-01-05 at 18 16 24" src="https://cloud.githubusercontent.com/assets/19776768/21687751/20f1cdf0-d373-11e6-9bfc-2edc13cb7077.png">
