### PR TITLE
Update trust-dns-resolver to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ exclude = [ ".gitignore", "circle.yml" ]
 
 [dependencies]
 chrono = "0.4"
-trust-dns-resolver = "0.19"
+trust-dns-resolver = "0.20"


### PR DESCRIPTION
This has a few implications for this library's dependencies. Notably:

- This moves this library into the Tokio 1.0 ecosystem
- The minimum Rustc version is bumped to 1.45 (released Sept 2020)

See <https://github.com/bluejekyll/trust-dns/blob/main/CHANGELOG.md#0200>
for the full trust-dns changelog.